### PR TITLE
Bump fixmyjs version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sublime-fixmyjs",
   "version": "0.3.2",
   "dependencies": {
-    "fixmyjs": "^0.13.6",
+    "fixmyjs": "^1.0.2",
     "get-stdin": "^3.0.0",
     "jshint": "^2.5.6"
   },


### PR DESCRIPTION
1.0.0 is a cut of the 0.13.7 release. 0.13.7 added the option `multiVar` which turns one-var style into multiVar. The rest of the changes are documented in the [CHANGELOG](https://github.com/jshint/fixmyjs/blob/master/CHANGELOG.md)