### PR TITLE
Fix on save

### DIFF
--- a/FixMyJS.sublime-settings
+++ b/FixMyJS.sublime-settings
@@ -1,3 +1,4 @@
 {
-    "legacy": true
+    "legacy": true,
+    "fixOnSave": false
 }

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,16 @@ In a js file, open the Command Palette *(Cmd+Shift+P)* and choose `FixMyJS`. You
 
 *(Preferences > Package Settings > FixMyJS > Settings - User)*
 
+#### Default
+
+```json
+{
+		"legacy": true,
+		"fixOnSave": false
+}
+```
+
+
 ### Legacy mode
 
 By default, this plugin uses the FixMyJS *legacy* mode. This option uses the last stable version


### PR DESCRIPTION
Uses `on_pre_save` event to run fix command on files with Javascript and Javascript (Babel) syntaxes.

Add field in FixMyJS.sublime-settings:

```
 {
    "fixOnSave": false
 }
```

Fixes https://github.com/addyosmani/sublime-fixmyjs/issues/8

Basically the same I did on [sublime-autoprefixer](https://github.com/sindresorhus/sublime-autoprefixer/pull/65)
